### PR TITLE
[Bug fix] iOS 13 not working & scrollview lock problem

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		637A73D229FAC2D2005D1669 /* ScreenshotPreventing in Frameworks */ = {isa = PBXBuildFile; productRef = 637A73D129FAC2D2005D1669 /* ScreenshotPreventing */; };
 		63E2DCF528ACA9D1000387F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2DCF428ACA9D1000387F1 /* AppDelegate.swift */; };
 		63E2DCF728ACA9D1000387F1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2DCF628ACA9D1000387F1 /* SceneDelegate.swift */; };
 		63E2DCF928ACA9D1000387F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2DCF828ACA9D1000387F1 /* ViewController.swift */; };
@@ -16,10 +17,10 @@
 		63E2DD0928ACAA17000387F1 /* TagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2DD0828ACAA17000387F1 /* TagView.swift */; };
 		63E2DD0B28ACAA28000387F1 /* UIView+Stacking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2DD0A28ACAA28000387F1 /* UIView+Stacking.swift */; };
 		63E2DD0E28ACAA44000387F1 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 63E2DD0D28ACAA44000387F1 /* SnapKit */; };
-		63E2DD1128ACAA61000387F1 /* ScreenshotPreventing in Frameworks */ = {isa = PBXBuildFile; productRef = 63E2DD1028ACAA61000387F1 /* ScreenshotPreventing */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		637A73CF29FAC289005D1669 /* ScreenshotPreventing-iOS */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "ScreenshotPreventing-iOS"; path = ../..; sourceTree = "<group>"; };
 		63E2DCF128ACA9D1000387F1 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63E2DCF428ACA9D1000387F1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63E2DCF628ACA9D1000387F1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,7 +38,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				63E2DD1128ACAA61000387F1 /* ScreenshotPreventing in Frameworks */,
+				637A73D229FAC2D2005D1669 /* ScreenshotPreventing in Frameworks */,
 				63E2DD0E28ACAA44000387F1 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -45,11 +46,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		637A73D029FAC2D2005D1669 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		63E2DCE828ACA9D1000387F1 = {
 			isa = PBXGroup;
 			children = (
 				63E2DCF328ACA9D1000387F1 /* Demo */,
 				63E2DCF228ACA9D1000387F1 /* Products */,
+				637A73D029FAC2D2005D1669 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -73,6 +82,7 @@
 				63E2DCFD28ACA9D2000387F1 /* Assets.xcassets */,
 				63E2DCFF28ACA9D2000387F1 /* LaunchScreen.storyboard */,
 				63E2DD0228ACA9D2000387F1 /* Info.plist */,
+				637A73CF29FAC289005D1669 /* ScreenshotPreventing-iOS */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -95,7 +105,7 @@
 			name = Demo;
 			packageProductDependencies = (
 				63E2DD0D28ACAA44000387F1 /* SnapKit */,
-				63E2DD1028ACAA61000387F1 /* ScreenshotPreventing */,
+				637A73D129FAC2D2005D1669 /* ScreenshotPreventing */,
 			);
 			productName = Demo;
 			productReference = 63E2DCF128ACA9D1000387F1 /* Demo.app */;
@@ -127,7 +137,6 @@
 			mainGroup = 63E2DCE828ACA9D1000387F1;
 			packageReferences = (
 				63E2DD0C28ACAA44000387F1 /* XCRemoteSwiftPackageReference "SnapKit" */,
-				63E2DD0F28ACAA61000387F1 /* XCRemoteSwiftPackageReference "ScreenshotPreventing" */,
 			);
 			productRefGroup = 63E2DCF228ACA9D1000387F1 /* Products */;
 			projectDirPath = "";
@@ -315,6 +324,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -343,6 +353,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -388,26 +399,17 @@
 				kind = branch;
 			};
 		};
-		63E2DD0F28ACAA61000387F1 /* XCRemoteSwiftPackageReference "ScreenshotPreventing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/yoxisem544/ScreenshotPreventing.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		637A73D129FAC2D2005D1669 /* ScreenshotPreventing */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ScreenshotPreventing;
+		};
 		63E2DD0D28ACAA44000387F1 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 63E2DD0C28ACAA44000387F1 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		63E2DD1028ACAA61000387F1 /* ScreenshotPreventing */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 63E2DD0F28ACAA61000387F1 /* XCRemoteSwiftPackageReference "ScreenshotPreventing" */;
-			productName = ScreenshotPreventing;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "screenshotpreventing",
+      "identity" : "rxswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/yoxisem544/ScreenshotPreventing.git",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
       "state" : {
-        "revision" : "5ea238eeff098ee75174afa144e68b0aaa34f3e0",
-        "version" : "1.0.2"
+        "revision" : "b4307ba0b6425c0ba4178e138799946c3da594f8",
+        "version" : "6.5.0"
       }
     },
     {

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -12,28 +12,31 @@ import ScreenshotPreventing
 class ViewController: UIViewController {
 
     let stack = UIView.hstack([], spacing: 24, distribution: .fillEqually)
-    lazy var hello = ScreenshotPreventingView(contentView: stack)
+    lazy var screenshotPreventView = ScreenshotPreventingView(contentView: stack)
+//    lazy var screenshotPreventView = ScreenshotPreventingView(contentView: tableView) // you can use this to test scrolling cases
 
-    let aSwitch = UISwitch()
-    let yayaLabel = UILabel()
+    let toggleSwitch = UISwitch()
+    let hintLabel = UILabel()
+
+    let tableView = UITableView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
 
-        view.addSubview(aSwitch)
-        aSwitch.snp.makeConstraints { make in
+        view.addSubview(toggleSwitch)
+        toggleSwitch.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-24)
         }
-        aSwitch.addTarget(self, action: #selector(hello(_:)), for: .valueChanged)
+        toggleSwitch.addTarget(self, action: #selector(hello(_:)), for: .valueChanged)
 
-        view.addSubview(yayaLabel)
-        yayaLabel.snp.makeConstraints { make in
+        view.addSubview(hintLabel)
+        hintLabel.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
-            make.bottom.equalTo(aSwitch.snp.top).offset(-24)
+            make.bottom.equalTo(toggleSwitch.snp.top).offset(-24)
         }
-        yayaLabel.textAlignment = .center
+        hintLabel.textAlignment = .center
 
         let one = ["a", "b", "c", "d", "e", "f"].enumerated().map { (index, word) -> TagView in
             let hello = TagView()
@@ -58,20 +61,36 @@ class ViewController: UIViewController {
         stack.layer.cornerRadius = 24
         stack.backgroundColor = .yellow
 
-        view.addSubview(hello)
-        hello.translatesAutoresizingMaskIntoConstraints = false
-        hello.snp.makeConstraints { make in
+        view.addSubview(screenshotPreventView)
+        screenshotPreventView.translatesAutoresizingMaskIntoConstraints = false
+        screenshotPreventView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(48)
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(24)
+            make.bottom.equalTo(hintLabel.snp.top).offset(-12).priority(.low)
         }
 
-        aSwitch.isOn = hello.preventScreenCapture
-        yayaLabel.text = "prevent capture \(aSwitch.isOn)"
+        toggleSwitch.isOn = screenshotPreventView.preventScreenCapture
+        hintLabel.text = "prevent capture \(toggleSwitch.isOn)"
+
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     }
 
     @objc func hello(_ aSwitch: UISwitch) {
-        hello.preventScreenCapture = aSwitch.isOn
-        yayaLabel.text = "prevent capture \(aSwitch.isOn)"
+        screenshotPreventView.preventScreenCapture = aSwitch.isOn
+        hintLabel.text = "prevent capture \(aSwitch.isOn)"
     }
 }
 
+extension ViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        100
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = "\(indexPath.row)"
+        return cell
+    }
+}

--- a/ScreenshotPreventing.podspec
+++ b/ScreenshotPreventing.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ScreenshotPreventing"
-  s.version = "1.2.1"
+  s.version = "1.2.2"
   s.summary = "Prevent screenshot or screenrecord on iOS devices"
   s. description = <<-EOS
   ScreenshotPreventing can help you to wrap views 

--- a/Sources/ScreenshotPreventing/HiddenContainerRecognizer.swift
+++ b/Sources/ScreenshotPreventing/HiddenContainerRecognizer.swift
@@ -39,6 +39,10 @@ struct HiddenContainerRecognizer {
             return "_UITextFieldCanvasView"
         }
 
+        if #available(iOS 13, *) {
+            return "_UITextFieldCanvasView"
+        }
+
         if #available(iOS 12, *) {
             return "_UITextFieldContentView"
         }

--- a/Sources/ScreenshotPreventing/ScreenshotPreventingView.swift
+++ b/Sources/ScreenshotPreventing/ScreenshotPreventingView.swift
@@ -18,6 +18,11 @@ public final class ScreenshotPreventingView: UIView {
         }
     }
 
+    /// Changing isUserInteractionEnabled value will also affect
+    /// isUserInteractionEnabled value of hidden content container.
+    ///
+    /// To sync isUserInteractionEnabled value is to prevent a freeze bug
+    /// that is going to happen if you add a scrollview inside `ScreenshotPreventingView`.
     public override var isUserInteractionEnabled: Bool {
         didSet {
             hiddenContentContainer?.isUserInteractionEnabled = isUserInteractionEnabled

--- a/Sources/ScreenshotPreventing/ScreenshotPreventingView.swift
+++ b/Sources/ScreenshotPreventing/ScreenshotPreventingView.swift
@@ -18,6 +18,12 @@ public final class ScreenshotPreventingView: UIView {
         }
     }
 
+    public override var isUserInteractionEnabled: Bool {
+        didSet {
+            hiddenContentContainer?.isUserInteractionEnabled = isUserInteractionEnabled
+        }
+    }
+
     private var contentView: UIView?
     private let textField = UITextField()
 
@@ -79,6 +85,7 @@ public final class ScreenshotPreventingView: UIView {
         guard let container = hiddenContentContainer else { return }
 
         container.addSubview(contentView)
+        container.isUserInteractionEnabled = isUserInteractionEnabled
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
         let bottomConstraint = contentView.bottomAnchor.constraint(equalTo: container.bottomAnchor)


### PR DESCRIPTION
Fix

1. in iOS 13, hidden container recognizer cannot find right view to add content to it. This cause a bug.
2. When adding a scrollview or tableview inside content view, view won't be able to react to scrolling event.

Also, tableview was added to demo project. Please try it out.