### PR TITLE
Remove background color for SwiftUI HostingVC

### DIFF
--- a/Sources/SwiftUI/ScreenshotPreventingView+Hosting.swift
+++ b/Sources/SwiftUI/ScreenshotPreventingView+Hosting.swift
@@ -47,6 +47,7 @@ final class ScreenshotPreventingHostingViewController<Content: View>: UIViewCont
 
         let hostVC = UIHostingController(rootView: content())
         hostVC.view.translatesAutoresizingMaskIntoConstraints = false
+        hostVC.view.backgroundColor = .clear
 
         addChild(hostVC)
         wrapperView.setup(contentView: hostVC.view)


### PR DESCRIPTION
Make sure hosting VC doesn't have a background color.
Still supports `.background` from the `content` view, but if no background is set, make sure it's transparent.
If the background is NOT set, the `UIHostingController` adds the default bg color for the current color scheme / appearance.

<details>
  <summary>Example</summary>

```swift
struct ContentView: View {
    var body: some View {
        VStack {
            Image(systemName: "globe")
                .imageScale(.large)
                .foregroundStyle(.tint)
            Text("Hello, World!")
                .screenshotProtected(isProtected: true)
        }
        .padding()
        .background(Color.red)
    }
}
```

![IMG_D50E121FE37E-1](https://github.com/yoxisem544/ScreenshotPreventing-iOS/assets/18512366/dd09bad7-73fa-4a0f-b980-406db1f9cd93)

</details>